### PR TITLE
MOD-6847: Extend INFO call to everything

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras = {
 
 setup(
     name='redis-info-provider',
-    version='0.14.0',
+    version='0.15.0',
     python_requires='>=2.7',
     package_dir={'': 'src'},
     packages=find_packages('src'),

--- a/src/redis_info_provider/info_poller.py
+++ b/src/redis_info_provider/info_poller.py
@@ -131,7 +131,7 @@ class InfoPoller(object):
 
                 # Will be stopped by a call to Greenlet.kill()
                 while True:
-                    info = redis_conn.info('all')
+                    info = redis_conn.info('everything')
                     self.logger.debug('Polled shard %s', shard.id)
                     info['meta'] = {}
                     shard.info = info


### PR DESCRIPTION
Extend the `INFO` call sent to the shards to collect the modules information as well, by dispatching the `INFO EVERYTHING` command instead of the `INFO ALL` command.